### PR TITLE
chore: make the createResource script async to fix file creation bug

### DIFF
--- a/scripts/createResource.js
+++ b/scripts/createResource.js
@@ -4,14 +4,6 @@ const name = process.argv[2];
 const nameLowerCase = name.toLowerCase();
 const dirPath = `./src/resources/${nameLowerCase}`;
 
-fs.mkdir(dirPath, err => {
-  if (err) {
-    throw err;
-  } else {
-    console.log(`Directory ${dirPath} created`);
-  }
-});
-
 const controller = `import crudControllers from '../../utils/crud';
 import ${name} from './${nameLowerCase}.model';
 
@@ -55,29 +47,43 @@ router
 export default router;
 `;
 
-// make controller.js file
-fs.writeFile(`${dirPath}/${nameLowerCase}.controller.js`, controller, err => {
-  if (err) {
-    throw err;
-  } else {
-    console.log(`File ${nameLowerCase}.controller.js created`);
-  }
-});
+async function makeDirAndFiles() {
+  await Promise.resolve(
+    fs.mkdir(dirPath, err => {
+      if (err) {
+        throw err;
+      } else {
+        console.log(`Directory ${dirPath} created`);
+      }
+    })
+  );
 
-// make model.js file
-fs.writeFile(`${dirPath}/${nameLowerCase}.model.js`, model, err => {
-  if (err) {
-    throw err;
-  } else {
-    console.log(`File ${nameLowerCase}.model.js created`);
-  }
-});
+  // make controller.js file
+  fs.writeFile(`${dirPath}/${nameLowerCase}.controller.js`, controller, err => {
+    if (err) {
+      throw err;
+    } else {
+      console.log(`File ${nameLowerCase}.controller.js created`);
+    }
+  });
 
-// make router.js file
-fs.writeFile(`${dirPath}/${nameLowerCase}.router.js`, router, err => {
-  if (err) {
-    throw err;
-  } else {
-    console.log(`File ${nameLowerCase}.router.js created`);
-  }
-});
+  // make model.js file
+  fs.writeFile(`${dirPath}/${nameLowerCase}.model.js`, model, err => {
+    if (err) {
+      throw err;
+    } else {
+      console.log(`File ${nameLowerCase}.model.js created`);
+    }
+  });
+
+  // make router.js file
+  fs.writeFile(`${dirPath}/${nameLowerCase}.router.js`, router, err => {
+    if (err) {
+      throw err;
+    } else {
+      console.log(`File ${nameLowerCase}.router.js created`);
+    }
+  });
+}
+
+makeDirAndFiles();


### PR DESCRIPTION
This fixes an issue where the `fs.writeFile` method is called before the `fs.mkdir` operation has completed, causing an arror to be thrown.

`fs.writeFile` now awaits the completion of `fs.mkdir` before attempting to create the files.