### PR TITLE
fix: change image property type to String in club resource

### DIFF
--- a/src/resources/club/club.model.js
+++ b/src/resources/club/club.model.js
@@ -2,17 +2,17 @@ import mongoose from 'mongoose';
 
 const clubSchema = new mongoose.Schema({
   image: {
-    type: Image,
-    required: true,
+    type: String,
+    required: true
   },
   link: {
     type: String,
-    required: true,  
+    required: true
   },
   title: {
     type: String,
     required: true
-  },
+  }
 });
 
 export default mongoose.model('club', clubSchema);


### PR DESCRIPTION
Change the image property type to String in the Club Resource.

Image is not a Mongoose Schema type, so was causing a crash.